### PR TITLE
Added include-dirs option

### DIFF
--- a/CacheWarmer/ThriftCompileCacheWarmer.php
+++ b/CacheWarmer/ThriftCompileCacheWarmer.php
@@ -76,6 +76,9 @@ class ThriftCompileCacheWarmer
             //Set Path
             $compiler->setModelPath($cacheDir);
 
+            //Set include dirs
+            $compiler->setIncludeDirs($config['includeDirs']);
+
             $compile = $compiler->compile($definitionPath, $config['server']);
 
             // Compilation Error

--- a/Command/CompileCommand.php
+++ b/Command/CompileCommand.php
@@ -33,6 +33,8 @@ class CompileCommand extends ContainerAwareCommand
 
         $this->addOption('bundleNameOut', null, InputOption::VALUE_OPTIONAL,
                 'Bundle where the Model will be located (default is the same than the definitions');
+        $this->addOption('includeDir', 'I', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Add a directory to the list of directories searched for include directives');
 	}
 
     /**
@@ -86,6 +88,12 @@ class CompileCommand extends ContainerAwareCommand
 
         //Set Path
         $compiler->setModelPath(sprintf('%s/%s', $bundlePath, ThriftCompileCacheWarmer::CACHE_SUFFIX));
+
+        //Set include dirs
+        if (($includeDirs = $input->getOption('includeDir'))) {
+            $compiler->setIncludeDirs($includeDirs);
+        }
+
 
         //Add namespace prefix if needed
         if($input->getOption('namespace'))

--- a/Compiler/ThriftCompiler.php
+++ b/Compiler/ThriftCompiler.php
@@ -30,6 +30,12 @@ class ThriftCompiler
     protected $modelPath;
 
     /**
+     * Included dirs
+     * @var string[]
+     */
+    protected $includeDirs = array();
+
+    /**
      * Base compiler options
      * @var array
      */
@@ -97,6 +103,15 @@ class ThriftCompiler
     }
 
     /**
+     * Add a directory to the list of directories searched for include directives
+     * @param string[] $includeDirs
+     */
+    public function setIncludeDirs($includeDirs)
+    {
+        $this->includeDirs = (array)$includeDirs;
+    }
+
+    /**
      * Set namespace prefix
      * @param string $namespace
      */
@@ -152,15 +167,25 @@ class ThriftCompiler
             $this->addServerCompile();
         }
 
+        // prepare includeDirs
+        $includeDirs = '';
+        foreach ($this->includeDirs as $includeDir) {
+            $includeDirs .= ' -I '. $includeDir;
+        }
+
         //Reset output
         $this->lastOutput = null;
 
-        exec(sprintf('%s -r -v --gen php:%s --out %s %s 2>&1',
+        $cmd = sprintf(
+            '%s -r -v --gen php:%s --out %s %s %s 2>&1',
             $this->getExecPath(),
             $this->compileOptions(),
             $this->modelPath,
+            $includeDirs,
             $definition
-        ), $this->lastOutput, $return);
+        );
+
+        exec($cmd, $this->lastOutput, $return);
 
         return (0 === $return) ? true : false;
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,10 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('protocol')->defaultValue('Thrift\Protocol\TBinaryProtocolAccelerated')->end()
                             ->scalarNode('transport')->defaultValue('Thrift\Transport\TBufferedTransport')->end()
                             ->booleanNode('server')->defaultFalse()->end()
+                            ->arrayNode('includeDirs')
+                                ->prototype('scalar')
+                                ->end()
+                            ->end()
                         ->end()
                         ->validate()
                             ->ifTrue(function($v){


### PR DESCRIPTION
This option allows to utilize thrift binary's -I option:
```
  -I dir      Add a directory to the list of directories
                searched for include directives
```
This option is useful for large hierarchical thrift definitions with multiple namespaces when it's better to include all the references.
Also I haven't added any documentation and would be happy if you do this. Though it's partially self-documenting since it presents in the configuration definition and in the command arguments. Thanks in advance.