### PR TITLE
Validate option

### DIFF
--- a/CacheWarmer/ThriftCompileCacheWarmer.php
+++ b/CacheWarmer/ThriftCompileCacheWarmer.php
@@ -79,6 +79,11 @@ class ThriftCompileCacheWarmer
             //Set include dirs
             $compiler->setIncludeDirs($config['includeDirs']);
 
+            //Add validate
+            if ($config['validate']) {
+                $compiler->addValidate();
+            }
+
             $compile = $compiler->compile($definitionPath, $config['server']);
 
             // Compilation Error

--- a/Command/CompileCommand.php
+++ b/Command/CompileCommand.php
@@ -102,6 +102,10 @@ class CompileCommand extends ContainerAwareCommand
             $compiler->setNamespacePrefix($input->getOption('namespace'));
         }
 
+        if ($input->getOption('validate')) {
+            $compiler->addValidate();
+        }
+
         $return = $compiler->compile($definitionPath, $input->getOption('server'));
 
         //Error

--- a/Command/CompileCommand.php
+++ b/Command/CompileCommand.php
@@ -28,6 +28,7 @@ class CompileCommand extends ContainerAwareCommand
         $this->addArgument('service', InputArgument::REQUIRED, 'Service name');
 
         $this->addOption('server', null, InputOption::VALUE_NONE, 'Generate server classes');
+        $this->addOption('validate', null, InputOption::VALUE_NONE, 'Generate PHP validator methods');
         $this->addOption('namespace', null, InputOption::VALUE_REQUIRED, 'Namespace prefix');
         $this->addOption('path', null, InputOption::VALUE_REQUIRED, 'Thrift exec path');
 

--- a/Compiler/ThriftCompiler.php
+++ b/Compiler/ThriftCompiler.php
@@ -121,6 +121,14 @@ class ThriftCompiler
     }
 
     /**
+     * Generate PHP validator methods
+     */
+    public function addValidate()
+    {
+        $this->options['validate'] = null;
+    }
+
+    /**
      * Compile server files too (processor)
      */
     protected function addServerCompile()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('protocol')->defaultValue('Thrift\Protocol\TBinaryProtocolAccelerated')->end()
                             ->scalarNode('transport')->defaultValue('Thrift\Transport\TBufferedTransport')->end()
                             ->booleanNode('server')->defaultFalse()->end()
+                            ->booleanNode('validate')->defaultFalse()->end()
                             ->arrayNode('includeDirs')
                                 ->prototype('scalar')
                                 ->end()


### PR DESCRIPTION
I've decided to refresh my pull request #10 I posted back in July I guess.
I believe it still can be useful for those who would like to use validation even taking #12 into account.
This one allows to use `validate` option in service definition.
As well, you can use --validate in the command line.
This option is then passed to the thrift compiler.