### PR TITLE
Proper routing

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,4 +1,3 @@
 thrift_server:
-    path:  /{extensionName}
-    defaults: { _controller: OverblogThriftBundle:Thrift:server }
-    methods: [POST]
+    resource: .
+    type: thrift

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -21,3 +21,8 @@ services:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 255 }
       - { name: kernel.event_listener, event: console.command, method: onConsoleCommand, priority: 255 }
 
+  thrift.routing.loader:
+    class: Overblog\ThriftBundle\Routing\ThriftRoutingLoader
+    arguments: [%thrift.config.servers%]
+    tags:
+      - { name: routing.loader, priority: 255 }

--- a/Routing/ThriftRoutingLoader.php
+++ b/Routing/ThriftRoutingLoader.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Overblog\ThriftBundle\Routing;
+
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class ThriftRoutingLoader extends Loader
+{
+
+    protected $services;
+
+    public function __construct($services)
+    {
+        $this->services = $services;
+    }
+
+    /**
+     * Loads a resource.
+     *
+     * @param mixed $resource The resource
+     * @param string|null $type The resource type or null if unknown
+     *
+     * @throws \Exception If something went wrong
+     */
+    public function load($resource, $type = null)
+    {
+        $coll = new RouteCollection();
+        foreach ($this->services as $path => $service) {
+            $route = new Route(
+                '/'.$path,
+                array('_controller' => 'ThriftBundle:Thrift:server'),
+                array(),
+                array(),
+                null,
+                array(),
+                array('post')
+            );
+            $coll->add('thrift.' . $service['service'], $route);
+        }
+        return $coll;
+    }
+
+    /**
+     * Returns whether this class supports the given resource.
+     *
+     * @param mixed $resource A resource
+     * @param string|null $type The resource type or null if unknown
+     *
+     * @return bool True if this class supports the given resource, false otherwise
+     */
+    public function supports($resource, $type = null)
+    {
+        return 'thrift' == $type;
+    }
+}


### PR DESCRIPTION
I've added a custom routing loader that creates routes for every thrift service defined.
I see the following advantaged over the `/{extensionName}`  path:
 1. proper handling of 404 errors in the project, instead of the `Method Not Allowed (Allow: POST)` error for all missing links in the project matching the `/{extensionName}` path.
 2. better inspectability: your version doesn't allow to see what exact routes lead to thrift services.
 3. thrift routing can now be defined first or in the middle. Your version practically requires it to be the last.

Example routes created by the loader in my project (app/console router:debug):
Before:
```
 thrift_server                                       POST   ANY    ANY  /{extensionName}                                          
```
After:
```
 thrift.server_queries_thrift                        POST   ANY    ANY  /server_queries                                           
 thrift.leaderboard_thrift                           POST   ANY    ANY  /leaderboards                                             
 thrift.multiplayer_thrift                           POST   ANY    ANY  /multiplayer                                              
 thrift.time_thrift                                  POST   ANY    ANY  /time                                                     
 thrift.chat_thrift                                  POST   ANY    ANY  /chat                                                     
 thrift.autotest_thrift                              POST   ANY    ANY  /auto_test                                                
 thrift.social_friends_thrift                        POST   ANY    ANY  /social_friends                                           
```