### PR TITLE
Fixed routing loader: missing extensionName

### DIFF
--- a/Routing/ThriftRoutingLoader.php
+++ b/Routing/ThriftRoutingLoader.php
@@ -30,7 +30,7 @@ class ThriftRoutingLoader extends Loader
         foreach ($this->services as $path => $service) {
             $route = new Route(
                 '/'.$path,
-                array('_controller' => 'ThriftBundle:Thrift:server'),
+                array('_controller' => 'ThriftBundle:Thrift:server', 'extensionName' => $path),
                 array(),
                 array(),
                 null,


### PR DESCRIPTION
I forgot to push one more commit. This is necessary to make the ThriftController work properly with routing loader.